### PR TITLE
Add an exported func to be able to set a new level color for Development mode

### DIFF
--- a/encode_level.go
+++ b/encode_level.go
@@ -2,6 +2,7 @@ package zlog
 
 import (
 	"log/slog"
+	"slices"
 
 	"github.com/icefed/zlog/buffer"
 )
@@ -19,18 +20,65 @@ const (
 	reset   = "\033[0m"
 )
 
+type lvlEscape struct {
+	slog.Level
+	string
+}
+
+var levelColorList []lvlEscape
+
+func init() {
+	UseDefaultLevelColors()
+}
+
 // formatColorLevelValue returns the string representation of the level.
 func formatColorLevelValue(buf *buffer.Buffer, l slog.Level) {
-	switch {
-	case l < slog.LevelInfo: // LevelDebug
-		buf.WriteString(magenta)
-	case l < slog.LevelWarn: // LevelInfo
-		buf.WriteString(blue)
-	case l < slog.LevelError: // LevelWarn
-		buf.WriteString(yellow)
-	default: // LevelError
-		buf.WriteString(red)
+	var mode lvlEscape
+	for _, mode = range levelColorList {
+		if l >= mode.Level {
+			break
+		}
 	}
+	buf.WriteString(mode.string)
 	buf.WriteString(l.String())
 	buf.WriteString(reset)
+}
+
+// UseDefaultLevelColors resets  the colors levels to the default configuration
+func UseDefaultLevelColors() {
+	levelColorList = []lvlEscape{
+		{slog.LevelError, red},
+		{slog.LevelWarn, yellow},
+		{slog.LevelInfo, blue},
+		{slog.LevelDebug, magenta},
+	}
+}
+
+// SetLevelColor adds (or overwrites) the global level color used in Development mode for a given logging
+// level, or anything above it and up to the next level.
+func SetLevelColor(l slog.Level, escape string) {
+	// We need to maintain the `levelColorList` in reverse order so the search works.
+
+	// And to avoid the need for lock etc (just in case someone calls this when logging calls might be made) we
+	// replace levelColorList whole sale with a new slice than edit it in place. That way either either get the
+	// whole new slice or the whole old slice.
+
+	newMode := lvlEscape{l, escape}
+	newList := slices.Clone(levelColorList)
+
+	targetPos := slices.IndexFunc(newList, func(mode lvlEscape) bool {
+		return l >= mode.Level
+	})
+
+	if targetPos == -1 {
+		// Position not found, stick it on the end
+		newList = append(newList, newMode)
+	} else if newList[targetPos].Level == l {
+		// Replace the current one
+		newList[targetPos] = newMode
+	} else {
+		newList = slices.Insert(newList, targetPos, newMode)
+	}
+
+	levelColorList = newList
 }


### PR DESCRIPTION
Add an exported func to be able to set a new level color for Development mode

I also added a `UseDefaultLevelColors` function to reset it back to the stock
list, mostly for being able to reset it back to stock in the unit tests.


This is _fractionally_ less efficient as it's now a loop rather
than a switch statement that can be unrolledm, but this is unavoidable if we
want it to be controllable by the developer at runtime.

Benchmark results:

```
BenchmarkLevelFormat/ERROR+5/new-12             12287250                94.46 ns/op
BenchmarkLevelFormat/ERROR+5/old-12             13530858                89.57 ns/op
BenchmarkLevelFormat/ERROR/new-12               100000000               12.95 ns/op
BenchmarkLevelFormat/ERROR/old-12               131831570               10.26 ns/op
BenchmarkLevelFormat/INFO/new-12                100000000               10.07 ns/op
BenchmarkLevelFormat/INFO/old-12                146790718                8.549 ns/op
BenchmarkLevelFormat/INFO+2/new-12              13149951                88.20 ns/op
BenchmarkLevelFormat/INFO+2/old-12              13251370                86.32 ns/op
BenchmarkLevelFormat/DEBUG/new-12               93846536                11.90 ns/op
BenchmarkLevelFormat/DEBUG/old-12               149301160                8.671 ns/op
BenchmarkLevelFormat/DEBUG-4/new-12             12009832                94.50 ns/op
BenchmarkLevelFormat/DEBUG-4/old-12             12207226                92.35 ns/op
```

(Note that the non-"Pure" levels are much slower anyway as `l.String()` hits a
fmt.Sprintf path inside slog package)

Here "old" is the current version on main using switch and "new" is the
version in this PR.

The benchmark code (not committed) was this:

```go
func BenchmarkLevelFormat(b *testing.B) {
	for _, lvl := range []slog.Level{
		slog.LevelError + 5,
		slog.LevelError,
		slog.LevelInfo,
		slog.LevelInfo + 2,
		slog.LevelDebug,
		slog.LevelDebug - 4,
	} {
		b.Run(lvl.String(), func(b *testing.B) {
			for _, fn := range []struct {
				name string
				fn   func(buf *buffer.Buffer, l slog.Level)
			}{
				{"new", formatColorLevelValue}, {"old", old},
			} {
				b.Run(fn.name, func(b *testing.B) {
					b.ResetTimer()
					buf := buffer.New()
					defer buf.Free()
					b.ResetTimer()
					for b.Loop() {
						fn.fn(buf, lvl)
					}
				})
			}
		})
	}
}

func old(buf *buffer.Buffer, l slog.Level) {
	switch {
	case l < slog.LevelInfo: // LevelDebug
		buf.WriteString(magenta)
	case l < slog.LevelWarn: // LevelInfo
		buf.WriteString(blue)
	case l < slog.LevelError: // LevelWarn
		buf.WriteString(yellow)
	default: // LevelError
		buf.WriteString(red)
	}
	buf.WriteString(l.String())
	buf.WriteString(reset)
}

```